### PR TITLE
Add support for macos and other home directories

### DIFF
--- a/Assign-AzureFinOpsRole.ps1
+++ b/Assign-AzureFinOpsRole.ps1
@@ -167,10 +167,9 @@ if ($tenant) {
 
     # Determine the operating system
     if ($IsWindows) {
-        $DirectoryPath = "C:\Crayon"
-    }
-    else {
-        $DirectoryPath = "/home/$(whoami)/Crayon"
+        $DirectoryPath = "C:\Test"
+    }else {
+        $DirectoryPath = "$home/Test"
     }
 
     # Check if the directory exists, if not, create it

--- a/Assign-AzureFinOpsRole.ps1
+++ b/Assign-AzureFinOpsRole.ps1
@@ -167,9 +167,9 @@ if ($tenant) {
 
     # Determine the operating system
     if ($IsWindows) {
-        $DirectoryPath = "C:\Test"
+        $DirectoryPath = "C:\crayon"
     }else {
-        $DirectoryPath = "$home/Test"
+        $DirectoryPath = "$home/crayon"
     }
 
     # Check if the directory exists, if not, create it


### PR DESCRIPTION
Added a $home variable on line 172 instead of hardcoding /home since MacOs uses a /Users folder instead of /home.
This will add support for MacOs users to run the script and any other home folder setup.

![image](https://github.com/user-attachments/assets/91154962-c87c-408e-a2da-e31175f2730c)
